### PR TITLE
feat(workflows): Delete artifacts in apply jobs for OpenTofu. The artifact is deleted to reduce the consumed storage and because once the OpenTofu changes have been applied they cannot be applied again

### DIFF
--- a/.github/workflows/opentofu-apply.yml
+++ b/.github/workflows/opentofu-apply.yml
@@ -55,6 +55,7 @@ jobs:
           apply-args: '${{ inputs.apply-args }} ${{ secrets.apply-args }}'
           version: '${{ inputs.version }}'
       - name: 'Delete ${{ inputs.artifact-name }}'
+        if: always()
         uses: cupel-co/actions/.github/actions/artifact/delete@v0.19.3
         with:
           name: '${{ inputs.artifact-name }}'

--- a/.github/workflows/opentofu-plan-and-apply.yml
+++ b/.github/workflows/opentofu-plan-and-apply.yml
@@ -117,6 +117,7 @@ jobs:
           apply-args: '${{ inputs.apply-args }} ${{ secrets.apply-args }}'
           version: '${{ inputs.version }}'
       - name: 'Delete ${{ inputs.artifact-name }}'
+        if: always()
         uses: cupel-co/actions/.github/actions/artifact/delete@v0.19.3
         with:
           name: '${{ inputs.artifact-name }}'


### PR DESCRIPTION
# GH-5 - feat(workflows): Delete artifacts in apply jobs for OpenTofu. The artifact is deleted to reduce the consumed storage and because once the OpenTofu changes have been applied they cannot be applied again

**[![Preview](https://github.com/cupel-co/workflows/actions/workflows/preview.yml/badge.svg?branch=feat/GH-5-delete-opentofu-artifacts&event=pull_request)](https://github.com/cupel-co/workflows/actions/workflows/preview.yml?query=branch%3Afeat/GH-5-delete-opentofu-artifacts)**

## Description
* feat(workflows): Delete artifacts in apply jobs for OpenTofu. The artifact is deleted to reduce the consumed storage and because once the OpenTofu changes have been applied they cannot be applied again
* closes GH-5

## Testing
- [x] Planned changes for all workspaces
- [x] Reviewed proposed changes
