### PR TITLE
fix: set action version to 0.25.0

### DIFF
--- a/.github/workflows/opentofu.cost.yml
+++ b/.github/workflows/opentofu.cost.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-tags: true
           ref: ${{ inputs.base-ref }}
       - name: Restore OpenTofu Modules
-        uses: cupel-co/actions/.github/actions/opentofu/get@v0.34.0
+        uses: cupel-co/actions/.github/actions/opentofu/get@v0.25.0
         with:
           version: '${{ inputs.opentofu-version }}'
           working-directory: ${{ inputs.working-directory }}
@@ -108,7 +108,7 @@ jobs:
           fetch-tags: true
           ref: ${{ inputs.head-ref }}
       - name: Restore OpenTofu Modules
-        uses: cupel-co/actions/.github/actions/opentofu/get@v0.34.0
+        uses: cupel-co/actions/.github/actions/opentofu/get@v0.25.0
         with:
           version: '${{ inputs.opentofu-version }}'
           working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
# #24 - fix: set action version to 0.25.0

[![Preview](https://github.com/cupel-co/workflows/actions/workflows/preview.yml/badge.svg?branch=fix/GH-24-fix-version&event=pull_request)](https://github.com/cupel-co/workflows/actions/workflows/preview.yml?query=branch%3Afix/GH-24-fix-version)

## Description
* closes #24
* 
* 
